### PR TITLE
Apply percent immediately for all pending operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ precedence (`×` and `÷` before `+` and `−`), decimals, percent, sign toggle,
 and backspace. The expression builds up above the display and stays visible
 with the result after `=`, so `42 × 3 + 7` reads back exactly as it was entered.
 
-Percent applies to the running total: with a pending operator, `%` shows the
-result immediately (`200 + 10 %` gives `220`, `200 × 10 %` gives `20`,
-`200 ÷ 10 %` gives `2000`). On its own, `x %` simply divides by 100.
+Percent resolves against the pending operator and shows the result immediately:
+`+` and `−` take that percentage of the running total (`200 + 10 %` gives `220`),
+while `×` and `÷` take a plain fraction (`200 × 10 %` gives `20`, `200 ÷ 10 %`
+gives `2000`). On its own, `x %` simply divides by 100.
 
 Everything works from the keyboard too:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ precedence (`×` and `÷` before `+` and `−`), decimals, percent, sign toggle,
 and backspace. The expression builds up above the display and stays visible
 with the result after `=`, so `42 × 3 + 7` reads back exactly as it was entered.
 
-Percent follows the familiar calculator convention: with a pending `+` or `−`
-it takes that percentage of the running total (`200 + 10 % =` gives `220`),
-while with `×` or `÷` — or on its own — it simply divides by 100.
+Percent applies to the running total: with a pending operator, `%` shows the
+result immediately (`200 + 10 %` gives `220`, `200 × 10 %` gives `20`,
+`200 ÷ 10 %` gives `2000`). On its own, `x %` simply divides by 100.
 
 Everything works from the keyboard too:
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -214,8 +214,8 @@ void Backend::pressEquals() {
     m_entry.clear();
 }
 
-// Percent always applies to the running total. With a pending operator,
-// 200 + 10% shows 220, 200 − 10% shows 180, 200 × 10% shows 20, and
+// Percent resolves against the pending operator and shows the result right
+// away: 200 + 10% shows 220, 200 − 10% shows 180, 200 × 10% shows 20, and
 // 200 ÷ 10% shows 2000. On its own, x% is simply x ÷ 100.
 void Backend::pressPercent() {
     if (m_errored)
@@ -234,36 +234,38 @@ void Backend::pressPercent() {
         return;
 
     if (!m_tokens.isEmpty() && isOperator(m_tokens.last())) {
-        QStringList leftSide = m_tokens;
-        leftSide.removeLast();
-        bool baseOk = false;
-        const double base = evaluateTokens(leftSide, &baseOk);
-        if (baseOk) {
-            const QString &op = m_tokens.last();
-            const double fraction = value / 100.0;
-            double total = 0;
+        // Resolve the percent into the operand the pending operator is waiting
+        // for, then evaluate the whole expression. Collapsing the left side
+        // into a single base instead would lose precedence, turning
+        // 2 + 3 × 10% into (2 + 3) × 0.1 rather than 2 + (3 × 0.1).
+        const QString op = m_tokens.last();
+        double operand = value / 100.0;
+        bool operandOk = true;
 
-            if (op == plusSign)
-                total = base + base * fraction;
-            else if (op == minusSign)
-                total = base - base * fraction;
-            else if (op == multiplySign)
-                total = base * fraction;
-            else if (op == divideSign)
-                total = base / fraction;
+        if (op == plusSign || op == minusSign) {
+            QStringList leftSide = m_tokens;
+            leftSide.removeLast();
+            const double base = evaluateTokens(leftSide, &operandOk);
+            operand = base * value / 100.0;
+        }
 
-            if (!std::isfinite(total))
-                return;
+        QStringList finalTokens = m_tokens;
+        finalTokens << QString::number(operand, 'g', 17);
+        bool totalOk = false;
+        const double total = evaluateTokens(finalTokens, &totalOk);
 
-            // Show the running total with the percent already applied, and
-            // preserve the original expression so the user sees 200 + 10%.
-            m_evaluatedExpression = prettyExpression(m_tokens) + QLatin1Char(' ')
-                                    + formatNumber(value) + QLatin1Char('%');
+        // Show the running total with the percent already applied, and
+        // preserve the original expression so the user sees 200 + 10%.
+        m_evaluatedExpression = prettyExpression(m_tokens) + QLatin1Char(' ')
+                                + formatNumber(value) + QLatin1Char('%');
+        m_entry.clear();
+        m_tokens.clear();
+        if (operandOk && totalOk) {
             m_resultValue = total;
             m_result = formatNumber(total);
             m_justEvaluated = true;
-            m_entry.clear();
-            m_tokens.clear();
+        } else {
+            m_errored = true;
         }
     } else {
         m_entry = formatNumber(value / 100.0);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -214,9 +214,9 @@ void Backend::pressEquals() {
     m_entry.clear();
 }
 
-// iOS-style percent: with a pending + or −, x% means x percent of the running
-// total, so 200 + 10 % = gives 220. With × or ÷ (or on its own) x% is simply
-// x ÷ 100, so 200 × 10 % = gives 20.
+// Percent always applies to the running total. With a pending operator,
+// 200 + 10% shows 220, 200 − 10% shows 180, 200 × 10% shows 20, and
+// 200 ÷ 10% shows 2000. On its own, x% is simply x ÷ 100.
 void Backend::pressPercent() {
     if (m_errored)
         return;
@@ -233,16 +233,41 @@ void Backend::pressPercent() {
     if (!ok)
         return;
 
-    double percent = value / 100.0;
-    if (!m_tokens.isEmpty() && (m_tokens.last() == plusSign || m_tokens.last() == minusSign)) {
+    if (!m_tokens.isEmpty() && isOperator(m_tokens.last())) {
         QStringList leftSide = m_tokens;
         leftSide.removeLast();
         bool baseOk = false;
         const double base = evaluateTokens(leftSide, &baseOk);
-        if (baseOk)
-            percent = base * value / 100.0;
+        if (baseOk) {
+            const QString &op = m_tokens.last();
+            const double fraction = value / 100.0;
+            double total = 0;
+
+            if (op == plusSign)
+                total = base + base * fraction;
+            else if (op == minusSign)
+                total = base - base * fraction;
+            else if (op == multiplySign)
+                total = base * fraction;
+            else if (op == divideSign)
+                total = base / fraction;
+
+            if (!std::isfinite(total))
+                return;
+
+            // Show the running total with the percent already applied, and
+            // preserve the original expression so the user sees 200 + 10%.
+            m_evaluatedExpression = prettyExpression(m_tokens) + QLatin1Char(' ')
+                                    + formatNumber(value) + QLatin1Char('%');
+            m_resultValue = total;
+            m_result = formatNumber(total);
+            m_justEvaluated = true;
+            m_entry.clear();
+            m_tokens.clear();
+        }
+    } else {
+        m_entry = formatNumber(value / 100.0);
     }
-    m_entry = formatNumber(percent);
 }
 
 void Backend::pressToggleSign() {

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -139,6 +139,37 @@ private slots:
         QCOMPARE(calculator.expression(), QStringLiteral("2000 × 2"));
     }
 
+    void percentKeepsPrecedence() {
+        Backend calculator;
+
+        // × and ÷ bind tighter than + and −, so the percent resolves against
+        // the operand beside it rather than the whole left-hand side.
+        press(calculator, "2 + 3 × 1 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("2.3"));
+
+        press(calculator, "clear 2 + 3 ÷ 1 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("32"));
+
+        press(calculator, "clear 1 0 + 2 × 3 %");
+        QCOMPARE(calculator.display(), QStringLiteral("10.06"));
+
+        // A pending + still takes its percentage of the running total.
+        press(calculator, "clear 2 × 3 + 1 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("6.6"));
+    }
+
+    void percentErrorsOnDivisionByZero() {
+        Backend calculator;
+
+        // Applying the percent divides by it, so a zero percent errors here
+        // rather than leaving the key silently dead.
+        press(calculator, "2 0 0 ÷ 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("Error"));
+
+        press(calculator, "clear 1 ÷ 0 + 5 %");
+        QCOMPARE(calculator.display(), QStringLiteral("Error"));
+    }
+
     void percentAndSign() {
         Backend calculator;
         press(calculator, "8 sign");

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -79,23 +79,64 @@ private slots:
     void percentOfRunningTotal() {
         Backend calculator;
 
-        // With a pending + or −, x% means x percent of the running total.
-        press(calculator, "2 0 0 + 1 0 % =");
+        // With a pending operator, x% shows the running total with the percent
+        // applied, so 200 + 10 % immediately reads 220.
+        press(calculator, "2 0 0 + 1 0 %");
         QCOMPARE(calculator.display(), QStringLiteral("220"));
+        QCOMPARE(calculator.expression(), QStringLiteral("200 + 10%"));
 
-        press(calculator, "clear 2 0 0 - 1 0 % =");
+        press(calculator, "=");
+        QCOMPARE(calculator.display(), QStringLiteral("220"));
+        QCOMPARE(calculator.expression(), QStringLiteral("200 + 10%"));
+
+        press(calculator, "clear 2 0 0 - 1 0 %");
         QCOMPARE(calculator.display(), QStringLiteral("180"));
+        QCOMPARE(calculator.expression(), QStringLiteral("200 − 10%"));
 
-        // With × or ÷, or standalone, x% is simply x ÷ 100.
-        press(calculator, "clear 2 0 0 × 1 0 % =");
+        // The same applies to × and ÷.
+        press(calculator, "clear 2 0 0 × 1 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("20"));
+        QCOMPARE(calculator.expression(), QStringLiteral("200 × 10%"));
+
+        press(calculator, "=");
         QCOMPARE(calculator.display(), QStringLiteral("20"));
 
+        press(calculator, "clear 2 0 0 ÷ 1 0 %");
+        QCOMPARE(calculator.display(), QStringLiteral("2000"));
+        QCOMPARE(calculator.expression(), QStringLiteral("200 ÷ 10%"));
+
+        press(calculator, "=");
+        QCOMPARE(calculator.display(), QStringLiteral("2000"));
+
+        // On its own, x% is simply x ÷ 100.
         press(calculator, "clear 5 0 %");
         QCOMPARE(calculator.display(), QStringLiteral("0.5"));
 
         // After equals, percent picks up from the result.
         press(calculator, "clear 4 0 + 1 0 = %");
         QCOMPARE(calculator.display(), QStringLiteral("0.5"));
+    }
+
+    void percentAppliesToRunningTotal() {
+        Backend calculator;
+
+        // A digit after the percent starts a fresh calculation.
+        press(calculator, "2 0 0 + 1 0 % 5");
+        QCOMPARE(calculator.display(), QStringLiteral("5"));
+        QCOMPARE(calculator.expression(), QString());
+
+        // An operator after the percent chains from the applied total.
+        press(calculator, "clear 2 0 0 + 1 0 % × 2 =");
+        QCOMPARE(calculator.display(), QStringLiteral("440"));
+        QCOMPARE(calculator.expression(), QStringLiteral("220 × 2"));
+
+        press(calculator, "clear 2 0 0 × 1 0 % + 5 =");
+        QCOMPARE(calculator.display(), QStringLiteral("25"));
+        QCOMPARE(calculator.expression(), QStringLiteral("20 + 5"));
+
+        press(calculator, "clear 2 0 0 ÷ 1 0 % × 2 =");
+        QCOMPARE(calculator.display(), QStringLiteral("4000"));
+        QCOMPARE(calculator.expression(), QStringLiteral("2000 × 2"));
     }
 
     void percentAndSign() {


### PR DESCRIPTION
## Summary
- Unifies the percent button behavior so the result is shown immediately for all four operators (`+`, `−`, `×`, `÷`).

#### Test plan
- [x] `./bin/test` passes
- [x] `./bin/build` succeeds