### PR TITLE
Keep display value anchored to the bottom on font shrink

### DIFF
--- a/src/Main.qml
+++ b/src/Main.qml
@@ -125,14 +125,17 @@ ApplicationWindow {
             }
 
             Text {
+                anchors.top: expressionText.bottom
+                anchors.topMargin: win.scaledSize(8)
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 anchors.right: parent.right
                 horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignBottom
                 text: backend.display
                 color: win.inkColor
                 fontSizeMode: Text.HorizontalFit
-                minimumPixelSize: win.scaledSize(22)
+                minimumPixelSize: win.scaledSize(32)
                 font.family: "iA Writer Mono S"
                 font.pixelSize: win.scaledSize(76)
             }


### PR DESCRIPTION
## Summary

When a long number forced the display font to shrink, the Text item's implicit height shrank with it and the number crept upward. This change:

- Gives the display value its own area below the expression (`anchors.top: expressionText.bottom; anchors.bottom: parent.bottom`).
- Aligns the display text to the bottom of that area (`verticalAlignment: Text.AlignBottom`).
- Raises the minimum pixel size from 22 to 32 so long results remain readable.

## Test plan

- [x] `./bin/test` passes (20/20).
- [x] `./bin/build` compiles successfully.
- [x] Manual check: long numbers keep the display text aligned to the bottom of the display area.