### PR TITLE
Add configurable decimal separator and fixed decimal places

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ Colors follow the current Omarchy theme (`~/.local/state/omarchy/current/theme/c
 and re-tint live when the theme changes. Text follows the desktop text size —
 `omarchy display text size`, or GNOME's `text-scaling-factor`.
 
+## Configuration
+
+Omacalc reads display preferences from `~/.config/Omacom/omacalc.conf`:
+
+```ini
+[display]
+decimalSeparator=comma
+fixedDecimalPlaces=2
+```
+
+- `decimalSeparator` accepts `dot` (default) or `comma`, so numbers can be
+  typed and displayed with either an English or a Brazilian-style decimal
+  point. A quoted `","` also works, but Qt's INI parser treats a bare,
+  unquoted `,` as a list separator and silently drops it — use `comma` to
+  avoid that pitfall. All internal parsing and math stay locale-independent;
+  only the digits shown to the user and the decimal key label change.
+- `fixedDecimalPlaces` is optional. When set, any calculation result that
+  isn't a whole number is shown with exactly that many decimal places, e.g.
+  `fixedDecimalPlaces=2` turns `10 ÷ 3` into `3.33`. Whole-number results such
+  as `4 + 6` still show as `10`. Leave it unset to keep the default, shortest
+  round-trip formatting.
+
 ## Requirements
 
 - Qt 6: `qt6-base`, `qt6-declarative`

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -185,7 +185,7 @@ ApplicationWindow {
                 CalcButton {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    label: modelData.label
+                    label: modelData.key === "." ? backend.decimalSeparator : modelData.label
                     keyValue: modelData.key
                     kind: modelData.kind
                     iconName: modelData.icon === undefined ? "" : modelData.icon

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -403,6 +403,11 @@ void Backend::pasteNumber() {
     text.replace(minusSign, QStringLiteral("-"));
     text.remove(QLatin1Char(' '));
 
+    // Copy hands out the configured separator, and the C locale reads a comma
+    // as a thousands group, so "1,500" would come back as 1500 rather than 1.5.
+    if (m_decimalSeparator != QStringLiteral("."))
+        text.replace(m_decimalSeparator, QStringLiteral("."));
+
     bool ok = false;
     double value = QLocale::c().toDouble(text, &ok);
     if (!ok) {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -38,6 +38,7 @@ QString sealNumber(const QString &entry) {
 }
 
 Backend::Backend(QObject *parent) : QObject(parent) {
+    loadDisplaySettings();
     loadOmarchyTheme();
     watchOmarchyTheme();
     connect(&m_themeWatcher, &QFileSystemWatcher::fileChanged, this, [this]() {
@@ -60,21 +61,45 @@ QString Backend::display() const {
     if (m_errored)
         return QStringLiteral("Error");
     if (!m_entry.isEmpty())
-        return m_entry;
+        return localizeNumber(m_entry);
     if (m_justEvaluated)
-        return m_result;
-    return formatNumber(QLocale::c().toDouble(currentValue()));
+        return localizeNumber(m_result);
+    return localizeNumber(formatResult(QLocale::c().toDouble(currentValue())));
 }
 
 // Operand tokens carry full round-trip precision when they come from a chained
-// result; present every number at display precision instead.
-QString Backend::prettyExpression(const QStringList &tokens) {
+// result; present every number at display precision instead. formatResult
+// applies the configured fixedDecimalPlaces, so an operand chained from a
+// rounded result (e.g. 5.67) doesn't reveal its full precision (5.66998476).
+QString Backend::prettyExpression(const QStringList &tokens) const {
     QStringList pretty;
     pretty.reserve(tokens.size());
     for (const QString &token : tokens)
         pretty << (isOperator(token) ? token
-                                     : formatNumber(QLocale::c().toDouble(token)));
+                                     : localizeNumber(formatResult(QLocale::c().toDouble(token))));
     return pretty.join(QLatin1Char(' '));
+}
+
+// Format a calculation result for display. Whole numbers are shown as plain
+// integers regardless of configuration. Non-integer results use the
+// configured fixed decimal places when set, so 10 ÷ 3 can show 3.33 instead
+// of Qt's shortest round-trip representation; otherwise formatNumber's
+// default significant-digit formatting applies.
+QString Backend::formatResult(double value) const {
+    double intPart = 0;
+    const bool isWholeNumber = std::isfinite(value) && std::modf(value, &intPart) == 0.0;
+    if (isWholeNumber || m_fixedDecimalPlaces < 0)
+        return formatNumber(value);
+    return QString::number(value, 'f', m_fixedDecimalPlaces);
+}
+
+// Present a C-locale number (always using '.') with the configured decimal
+// separator, so the internal math and parsing logic never has to change.
+QString Backend::localizeNumber(const QString &number) const {
+    if (m_decimalSeparator == QStringLiteral("."))
+        return number;
+    QString localized = number;
+    return localized.replace(QLatin1Char('.'), m_decimalSeparator);
 }
 
 // The number the calculator is "at" right now: the entry being typed, or the
@@ -207,7 +232,7 @@ void Backend::pressEquals() {
         m_errored = true;
     } else {
         m_resultValue = value;
-        m_result = formatNumber(value);
+        m_result = formatResult(value);
         m_justEvaluated = true;
     }
     m_tokens.clear();
@@ -496,6 +521,25 @@ void Backend::loadOmarchyTheme() {
     }
 
     emit themeColorsChanged();
+}
+
+// Read display preferences from ~/.config/Omacom/omacalc.conf. A bare ","
+// in an INI value is a list separator to Qt's parser, so also accept the
+// words "comma"/"dot" to spare users from having to quote it.
+void Backend::loadDisplaySettings() {
+    const QSettings settings;
+    const QString separator = settings.value(QStringLiteral("display/decimalSeparator"),
+                                              QStringLiteral(".")).toString().trimmed();
+    if (separator == QStringLiteral(",") || separator.compare(QStringLiteral("comma"), Qt::CaseInsensitive) == 0)
+        m_decimalSeparator = QStringLiteral(",");
+    else
+        m_decimalSeparator = QStringLiteral(".");
+
+    // fixedDecimalPlaces is optional; absent or negative disables it and
+    // results keep their natural precision.
+    bool ok = false;
+    const int places = settings.value(QStringLiteral("display/fixedDecimalPlaces"), -1).toInt(&ok);
+    m_fixedDecimalPlaces = (ok && places >= 0) ? std::min(places, 15) : -1;
 }
 
 void Backend::watchOmarchyTheme() {

--- a/src/backend.h
+++ b/src/backend.h
@@ -10,6 +10,7 @@ class Backend : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString expression READ expression NOTIFY calculationChanged)
     Q_PROPERTY(QString display READ display NOTIFY calculationChanged)
+    Q_PROPERTY(QString decimalSeparator READ decimalSeparator CONSTANT)
     Q_PROPERTY(bool darkMode READ darkMode WRITE setDarkMode NOTIFY darkModeChanged)
     Q_PROPERTY(qreal textScale READ textScale WRITE setTextScale NOTIFY textScaleChanged)
     Q_PROPERTY(QString themeBackground READ themeBackground NOTIFY themeColorsChanged)
@@ -22,6 +23,7 @@ public:
 
     QString expression() const;
     QString display() const;
+    QString decimalSeparator() const { return m_decimalSeparator; }
 
     bool darkMode() const { return m_darkMode; }
     void setDarkMode(bool darkMode);
@@ -34,6 +36,8 @@ public:
 
     static double evaluateTokens(const QStringList &tokens, bool *ok);
     static QString formatNumber(double value);
+    QString formatResult(double value) const;
+    QString localizeNumber(const QString &number) const;
 
     Q_INVOKABLE void pressKey(const QString &key);
     Q_INVOKABLE void copyResult() const;
@@ -60,9 +64,10 @@ private:
     QString currentValue() const;
     void beginEditingAfterResult();
     void clearEvaluation();
-    static QString prettyExpression(const QStringList &tokens);
+    QString prettyExpression(const QStringList &tokens) const;
     void loadOmarchyTheme();
     void watchOmarchyTheme();
+    void loadDisplaySettings();
 
     QStringList m_tokens;
     QString m_entry;
@@ -74,6 +79,8 @@ private:
 
     bool m_darkMode = true;
     qreal m_textScale = 1.0;
+    QString m_decimalSeparator = QStringLiteral(".");
+    int m_fixedDecimalPlaces = -1;
     QString m_themeBackground;
     QString m_themeForeground;
     QString m_themeAccent;

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -218,6 +218,78 @@ private slots:
         QCOMPARE(Backend::formatNumber(1e15), QStringLiteral("1e+15"));
     }
 
+    void respectsDecimalSeparatorConfig() {
+        {
+            QSettings settings;
+            settings.setValue(QStringLiteral("display/decimalSeparator"), QStringLiteral("comma"));
+        }
+
+        Backend calculator;
+        QCOMPARE(calculator.decimalSeparator(), QStringLiteral(","));
+
+        press(calculator, "1 . 5 + 1 . 5 =");
+        QCOMPARE(calculator.display(), QStringLiteral("3"));
+
+        press(calculator, "clear 1 . 5 0 0");
+        QCOMPARE(calculator.display(), QStringLiteral("1,500"));
+
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("display/decimalSeparator"));
+        }
+    }
+
+    void respectsFixedDecimalPlacesConfig() {
+        {
+            QSettings settings;
+            settings.setValue(QStringLiteral("display/fixedDecimalPlaces"), 2);
+        }
+
+        Backend calculator;
+
+        // A float result is padded/rounded to the configured precision.
+        press(calculator, "1 0 ÷ 3 =");
+        QCOMPARE(calculator.display(), QStringLiteral("3.33"));
+
+        press(calculator, "clear 1 . 5 + 1 . 6 =");
+        QCOMPARE(calculator.display(), QStringLiteral("3.10"));
+
+        // Whole-number results stay plain integers regardless of the setting,
+        // even when the operands were typed with a decimal point.
+        press(calculator, "clear 1 . 5 + 1 . 5 =");
+        QCOMPARE(calculator.display(), QStringLiteral("3"));
+
+        press(calculator, "clear 4 + 6 =");
+        QCOMPARE(calculator.display(), QStringLiteral("10"));
+
+        // Chaining from a rounded result keeps the expression consistent with
+        // the display instead of revealing the full-precision value: the
+        // operand reads 3.33, not 3.33333333333333.
+        press(calculator, "clear 1 0 ÷ 3 = + 1 =");
+        QCOMPARE(calculator.expression(), QStringLiteral("3.33 + 1"));
+
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("display/fixedDecimalPlaces"));
+        }
+    }
+
+    void emptyFixedDecimalPlacesKeepsDefaultFormatting() {
+        {
+            QSettings settings;
+            settings.setValue(QStringLiteral("display/fixedDecimalPlaces"), QString());
+        }
+
+        Backend calculator;
+        press(calculator, "1 0 ÷ 3 =");
+        QCOMPARE(calculator.display(), Backend::formatNumber(10.0 / 3.0));
+
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("display/fixedDecimalPlaces"));
+        }
+    }
+
     void loadsCurrentOmarchyTheme() {
         QTemporaryDir homeDirectory;
         QVERIFY(homeDirectory.isValid());

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -233,6 +233,13 @@ private slots:
         press(calculator, "clear 1 . 5 0 0");
         QCOMPARE(calculator.display(), QStringLiteral("1,500"));
 
+        // What the calculator copies, it has to be able to paste back: the C
+        // locale reads "1,500" as a thousands group and would return 1500.
+        calculator.copyResult();
+        press(calculator, "clear");
+        calculator.pasteNumber();
+        QCOMPARE(calculator.display(), QStringLiteral("1,5"));
+
         {
             QSettings settings;
             settings.remove(QStringLiteral("display/decimalSeparator"));


### PR DESCRIPTION
## Summary
- Adds two optional display preferences read from `~/.config/Omacom/omacalc.conf`:
  - `decimalSeparator` (`dot` or `comma`) lets numbers be typed and displayed with a Brazilian-style comma instead of a period. All internal parsing and math stay locale-independent; only the presented digits and the decimal key label change.
  - `fixedDecimalPlaces` rounds non-integer results to a fixed number of decimal places (e.g. `10 ÷ 3` becomes `3.33` with `fixedDecimalPlaces=2`), while whole-number results (`4 + 6`) keep showing as plain integers. Left unset, formatting is unchanged.
- Chained operands and expressions reflect the same rounding as the result they came from, instead of leaking full floating-point precision (e.g. `3.33 + 1`, not `3.33333333333333 + 1`).

#### Test plan
- [x] `./bin/test` passes
- [x] `./bin/build` succeeds