### PR TITLE
fix: Strip trailing comments when reading the theme palette

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -29,6 +29,7 @@ bool isOperator(const QString &token) {
 // '#' themselves, so only a '#' outside a string starts a comment.
 QString stripTomlComment(const QString &line) {
     QChar quote;
+    int valueStart = -1;
     for (int i = 0; i < line.size(); ++i) {
         const QChar character = line.at(i);
         if (!quote.isNull()) {
@@ -38,7 +39,13 @@ QString stripTomlComment(const QString &line) {
                 ++i;
         } else if (character == QLatin1Char('"') || character == QLatin1Char('\'')) {
             quote = character;
+        } else if (character == QLatin1Char('=') && valueStart < 0) {
+            valueStart = i + 1;
         } else if (character == QLatin1Char('#')) {
+            // An unquoted value is a bare "#rrggbb", so the first '#' after the
+            // '=' opens the value; only a later one starts a comment.
+            if (valueStart >= 0 && line.mid(valueStart, i - valueStart).trimmed().isEmpty())
+                continue;
             return line.left(i);
         }
     }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -25,6 +25,26 @@ bool isOperator(const QString &token) {
         || token == multiplySign || token == divideSign;
 }
 
+// Theme values might carry a trailing "# note" comment, and hex colors open with
+// '#' themselves, so only a '#' outside a string starts a comment.
+QString stripTomlComment(const QString &line) {
+    QChar quote;
+    for (int i = 0; i < line.size(); ++i) {
+        const QChar character = line.at(i);
+        if (!quote.isNull()) {
+            if (character == quote)
+                quote = QChar();
+            else if (character == QLatin1Char('\\') && quote == QLatin1Char('"'))
+                ++i;
+        } else if (character == QLatin1Char('"') || character == QLatin1Char('\'')) {
+            quote = character;
+        } else if (character == QLatin1Char('#')) {
+            return line.left(i);
+        }
+    }
+    return line;
+}
+
 // Digits are entered raw, so "5." and "-" can linger while typing. Seal them
 // into plain numbers before they join the expression.
 QString sealNumber(const QString &entry) {
@@ -445,8 +465,8 @@ void Backend::loadOmarchyTheme() {
     if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         QTextStream in(&file);
         while (!in.atEnd()) {
-            const QString line = in.readLine().trimmed();
-            if (line.isEmpty() || line.startsWith(QLatin1Char('#')))
+            const QString line = stripTomlComment(in.readLine()).trimmed();
+            if (line.isEmpty())
                 continue;
 
             const int equals = line.indexOf(QLatin1Char('='));

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -252,6 +252,41 @@ private slots:
         QVERIFY(!calculator.darkMode());
     }
 
+    void ignoresCommentsInOmarchyTheme() {
+        QTemporaryDir homeDirectory;
+        QVERIFY(homeDirectory.isValid());
+
+        const QByteArray originalHome = qgetenv("HOME");
+        struct HomeRestorer {
+            QByteArray value;
+            ~HomeRestorer() { qputenv("HOME", value); }
+        } restoreHome{originalHome};
+        QVERIFY(qputenv("HOME", homeDirectory.path().toUtf8()));
+
+        const QString themeDirectory = homeDirectory.path()
+            + QStringLiteral("/.local/state/omarchy/current/theme");
+        QVERIFY(QDir().mkpath(themeDirectory));
+
+        QFile colorsFile(themeDirectory + QStringLiteral("/colors.toml"));
+        QVERIFY(colorsFile.open(QIODevice::WriteOnly | QIODevice::Text));
+        const QByteArray palette(
+            "# A theme that annotates every value.\n"
+            "mode = \"dark\"  # matches the ramp\n"
+            "accent    = \"#56a8f5\"  # function declaration\n"
+            "selection = \"#2a4371\"  # selection-bg-active (blue-50)\n"
+            "background = \"#191a1c\"  # layer-0-bg\n"
+            "foreground = \"#bcbec4\"  # editor-text\n");
+        QCOMPARE(colorsFile.write(palette), qint64(palette.size()));
+        colorsFile.close();
+
+        Backend calculator;
+        QCOMPARE(calculator.themeBackground(), QStringLiteral("#191a1c"));
+        QCOMPARE(calculator.themeForeground(), QStringLiteral("#bcbec4"));
+        QCOMPARE(calculator.themeAccent(), QStringLiteral("#56a8f5"));
+        QCOMPARE(calculator.themeSelection(), QStringLiteral("#2a4371"));
+        QVERIFY(calculator.darkMode());
+    }
+
 private:
     QTemporaryDir m_settingsDirectory;
 };

--- a/tests/tst_omacalc.cpp
+++ b/tests/tst_omacalc.cpp
@@ -285,6 +285,23 @@ private slots:
         QCOMPARE(calculator.themeAccent(), QStringLiteral("#56a8f5"));
         QCOMPARE(calculator.themeSelection(), QStringLiteral("#2a4371"));
         QVERIFY(calculator.darkMode());
+
+        // A bare hex value opens with the same '#' a comment does.
+        QVERIFY(colorsFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text));
+        const QByteArray bare(
+            "mode = \"dark\"\n"
+            "accent = #56a8f5\n"
+            "selection = #2a4371  # selection-bg-active\n"
+            "background = #191a1c\n"
+            "foreground = #bcbec4  # editor-text\n");
+        QCOMPARE(colorsFile.write(bare), qint64(bare.size()));
+        colorsFile.close();
+
+        Backend bareCalculator;
+        QCOMPARE(bareCalculator.themeBackground(), QStringLiteral("#191a1c"));
+        QCOMPARE(bareCalculator.themeForeground(), QStringLiteral("#bcbec4"));
+        QCOMPARE(bareCalculator.themeAccent(), QStringLiteral("#56a8f5"));
+        QCOMPARE(bareCalculator.themeSelection(), QStringLiteral("#2a4371"));
     }
 
 private:


### PR DESCRIPTION
`Backend::loadOmarchyTheme()` only treated `#` as a comment when it opened the line, so a theme that annotates its values broke the palette:

```toml
accent    = "#56a8f5"  # scheme: function declaration
```

`accent` came back as the literal `"#56a8f5"  # scheme: function declaration`. The quote-stripping check fails because the last character isn't a quote, the value overwrites the default anyway, and QML ends up with an invalid color. 

This would result in omacalc showing a all-black window.

## Fix

`stripTomlComment()` scans for a `#` outside a string, so a comment ends the line while the hex values — which open with `#` themselves — survive. Escaped quotes in basic strings are handled too. The loop's old `startsWith('#')` skip is gone, since a whole-line comment now strips to empty.

## Testing

Added `ignoresCommentsInOmarchyTheme`, whose fixture annotates every value the way a real theme does. It fails against the old parser and passes with the fix; the full suite is 20/20.

Not handled, deliberately: multi-line arrays, quoted keys, and `\uXXXX` unescaping. None appear in Omarchy theme files, and covering them means writing a real TOML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/omacom/omacalc/issues/12